### PR TITLE
Add IAsyncDisposable to TextReader (issue #88244)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
@@ -17,7 +17,7 @@ namespace System.IO
     //
     // This class is intended for character input, not bytes.
     // There are methods on the Stream class for reading bytes.
-    public abstract partial class TextReader : MarshalByRefObject, IDisposable
+    public abstract partial class TextReader : MarshalByRefObject, IDisposable, IAsyncDisposable
     {
         // Create our own instance to avoid static field initialization order problems on Mono.
         public static readonly TextReader Null = new StreamReader.NullStreamReader();
@@ -34,6 +34,12 @@ namespace System.IO
         {
             Dispose(true);
             GC.SuppressFinalize(this);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Dispose();
+            return default
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextReader.cs
@@ -39,7 +39,7 @@ namespace System.IO
         public ValueTask DisposeAsync()
         {
             Dispose();
-            return default
+            return default;
         }
 
         protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
Test PR for iteration push validation. Contains deliberate syntax error (missing semicolon in DisposeAsync).